### PR TITLE
Add site key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-# reCAPTCHA site key for authentication
-VITE_RECAPTCHA_SITE_KEY=your_recaptcha_site_key_here

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const USERNAME_COOKIE = "username";
 const PASSWORD_COOKIE = "password";
 const REMEMBER_ME_COOKIE = "remember_me";
 const COOKIE_EXPIRY = 28; // days
-const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+const RECAPTCHA_SITE_KEY = "6LefrcAqAAAAAAtZfDekeyxDXnwy872FU7phEwwc";
 
 function calculateAttendanceProjection(present: number, total: number) {
   const currentPercentage = (present / total) * 100;


### PR DESCRIPTION
The website was crashing because the reCAPTCHA site key was being loaded from environment variables, which weren't properly configured in the Vercel deployment. 

I've hardcoded the site key directly in the TSX file to fix this issue. Since it's a public key that's visible in the browser anyway, this doesn't pose any security concerns while ensuring the application works properly in all environments.

This resolves the "Missing required parameters: sitekey" error that was appearing in the deployed version.