### PR TITLE
Add What-If Projection Feature

### DIFF
--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -25,7 +25,9 @@ export interface AttendanceResponse {
     attendanceCourseComponentInfoList: {
       courseName: string;
       courseCode: string;
+      courseId: number; // Added for daywise attendance payload
       attendanceCourseComponentNameInfoList: {
+        courseComponentId: number; // Added for daywise attendance payload
         numberOfExtraAttendance: number;
         componentName: string;
         numberOfPeriods: number;
@@ -49,4 +51,24 @@ export interface Course {
     presentPercentage: number | null;
     presentPercentageWith: string;
   }[];
+}
+
+// --- Types for the 'What-if' Projection feature ---
+
+export interface ScheduleEntry {
+  id: string | null;
+  start: string;
+  end: string;
+  title: string;
+  courseName: string;
+  courseCode: string;
+  courseCompName: string;
+  facultyName: string;
+  lectureDate: string; // e.g., "10/01/2024"
+  type: 'CLASS' | 'HOLIDAY';
+}
+
+export interface ScheduleResponse {
+  data: ScheduleEntry[];
+  message: string;
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -8,7 +8,7 @@ export async function fetchStudentId(token: string): Promise<number | null> {
     );
 
     if (response.data.data.length > 0) {
-      return response.data.data[0].studentId; // Assume studentId is same for all items
+      return response.data.data[0].studentId;
     } else {
       return null;
     }
@@ -16,4 +16,28 @@ export async function fetchStudentId(token: string): Promise<number | null> {
     console.error("Error fetching registered courses", error);
     return null;
   }
+}
+
+export function getWeekRange() {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const dayOfWeek = today.getDay();
+
+  const startDate = new Date(today); 
+  startDate.setDate(today.getDate() - dayOfWeek);
+
+  const endDate = new Date(startDate); 
+  endDate.setDate(startDate.getDate() + 6);
+
+  const formatDate = (date: Date) => {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  };
+
+  return {
+    startDate: formatDate(startDate),
+    endDate: formatDate(endDate),
+  };
 }


### PR DESCRIPTION
This PR introduces a "what-if" projection feature. It allows students to see how their attendance percentage will be affected if they plan to miss upcoming classes.

The app now fetches the user's weekly timetable after logging in.
I added a "Show Projection" toggle button (with a 🪄 icon) next to the logout button.
When toggled, a new card appears showing all upcoming classes for the rest of the week (from today onwards).
Users can check the box next to any class they plan to miss.
When a class is checked, the "Overall Attendance" card and all "Subject" cards instantly update to show the new projected  percentage and hide the "need to attend / present" messages for a cleaner look.