### PR TITLE
add skeleton loader to DaywiseReport loading state

### DIFF
--- a/src/components/Daywise.tsx
+++ b/src/components/Daywise.tsx
@@ -14,6 +14,25 @@ function formatDate(dateString: string) {
 	return `${day}-${month}-${year}`;
 }
 
+function SkeletonRow() {
+	return (
+		<tr className="animate-pulse">
+			<td className="p-3 border">
+				<div className="h-4 bg-gray-200 rounded w-16 mx-auto" />
+			</td>
+			<td className="p-3 border">
+				<div className="h-4 bg-gray-200 rounded w-10 mx-auto" />
+			</td>
+			<td className="p-3 border">
+				<div className="h-4 bg-gray-200 rounded w-28 mx-auto" />
+			</td>
+			<td className="p-3 border">
+				<div className="h-4 bg-gray-200 rounded w-16 mx-auto" />
+			</td>
+		</tr>
+	);
+}
+
 function DaywiseReport({ token, payload }: DaywiseReportProps) {
 	const [daywiseData, setDaywiseData] = useState<LectureListProps[]>([]);
 	const [loading, setLoading] = useState<boolean>(true);
@@ -60,9 +79,8 @@ function DaywiseReport({ token, payload }: DaywiseReportProps) {
 		fetchDaywiseAttendance();
 	}, [token, payload]);
 
-	if (loading) return <p>Loading daywise attendance data...</p>;
 	if (error) return <p className="text-red-600">{error}</p>;
-	if (daywiseData.length === 0)
+	if (!loading && daywiseData.length === 0)
 		return <p>No daywise attendance data available.</p>;
 
 	return (
@@ -76,28 +94,43 @@ function DaywiseReport({ token, payload }: DaywiseReportProps) {
 						<th className="p-3 sm:p-3 border">Attendance</th>
 					</tr>
 				</thead>
-				<tbody className="text-center text-gray-800 text-sm">
-					{daywiseData.map((lecture) => (
-						<tr
-							key={`${lecture.planLecDate}-${lecture.timeSlot}`}
-							className="hover:bg-gray-50 transition-colors"
-						>
-							<td className="p-2 border">{formatDate(lecture.planLecDate)}</td>
-							<td className="p-2 border">{lecture.dayName.substring(0, 3)}</td>
-							<td className="p-2 border text-xs">{lecture.timeSlot}</td>
-							<td className="p-2 border font-semibold">
-								{lecture.attendance === "PRESENT" && (
-									<span className="text-green-600">{lecture.attendance}</span>
-								)}
-								{lecture.attendance === "ADJUSTED" && (
-									<span className="text-green-800">{lecture.attendance}</span>
-								)}
-								{lecture.attendance === "ABSENT" && (
-									<span className="text-red-600">{lecture.attendance}</span>
-								)}
-							</td>
-						</tr>
-					))}
+				<tbody
+					className={`text-center text-gray-800 text-sm ${!loading ? "style-fade-opacity" : ""}`}
+				>
+					{loading ? (
+						<>
+							<SkeletonRow />
+							<SkeletonRow />
+							<SkeletonRow />
+							<SkeletonRow />
+						</>
+					) : (
+						daywiseData.map((lecture) => (
+							<tr
+								key={`${lecture.planLecDate}-${lecture.timeSlot}`}
+								className="hover:bg-gray-50 transition-colors"
+							>
+								<td className="p-2 border">
+									{formatDate(lecture.planLecDate)}
+								</td>
+								<td className="p-2 border">
+									{lecture.dayName.substring(0, 3)}
+								</td>
+								<td className="p-2 border text-xs">{lecture.timeSlot}</td>
+								<td className="p-2 border font-semibold">
+									{lecture.attendance === "PRESENT" && (
+										<span className="text-green-600">{lecture.attendance}</span>
+									)}
+									{lecture.attendance === "ADJUSTED" && (
+										<span className="text-green-800">{lecture.attendance}</span>
+									)}
+									{lecture.attendance === "ABSENT" && (
+										<span className="text-red-600">{lecture.attendance}</span>
+									)}
+								</td>
+							</tr>
+						))
+					)}
 				</tbody>
 			</table>
 		</div>

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,19 @@
 	animation: fadeIn 0.5s ease-out forwards;
 }
 
+@keyframes fadeOpacity {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+.style-fade-opacity {
+	animation: fadeOpacity 0.4s ease-out forwards;
+}
+
 @media (max-width: 330px) {
 	.hide-text-below-352 {
 		display: none;


### PR DESCRIPTION
Closes #42 

## What this fixes

When a user clicks "See Daywise Attendance", `DaywiseReport` in `Daywise.tsx` was doing an early return with a plain `<p>` tag while `fetchDaywiseAttendance` was in progress. This meant the modal had no structure during loading and the four column headers (Date, Day, Time Slot, Attendance) which are statically defined in the component and have no dependency on the ERP response were staying hidden for no reason.

## What I changed

**`src/components/Daywise.tsx`**
- Removed the `if (loading) return <p>Loading daywise attendance data...</p>` early return
- Added a `SkeletonRow` component directly above `DaywiseReport` that renders one animated placeholder row matching the four-column table structure
- During loading, `<tbody>` now renders 4 `SkeletonRow` instances instead of the plain text. 4 rows is intentional — the industry standard for skeleton loaders is to show fewer rows than what is actually expected, same approach Instagram and YouTube use for their loading states
- Added a `!loading` guard to the `daywiseData.length === 0` check so the "no data" message doesn't fire prematurely while the request is still pending
- Applied a `style-fade-opacity` class conditionally on `<tbody>` so real data fades in cleanly once the response arrives

**`src/index.css`**
- Added a `fadeOpacity` keyframe and `.style-fade-opacity` class that does a pure `opacity: 0 → 1` transition. Kept this separate from the existing `style-fade-in` intentionally since `style-fade-in` also applies a `translateY` which is too strong for individual table rows and affects other components across the app

## Screenshot
<img width="1920" height="1080" alt="Screenshot from 2026-08-26 13-47-47" src="https://github.com/user-attachments/assets/c1c3a8a4-5ed4-4cf6-9ad4-f6925d256ff6" />

<!-- attach your skeleton loader screenshot here -->

## Checklist

- [x] These changes have no impact on load performance and introduce zero additional network requests or lag
- [x] I have read and understood all the relevant code touched by this PR properly before making changes
- [x] AI USAGE -  AI was used only to help understand the codebase, discuss implementation approach, and help write this PR description. All code was implemented, tested and reviewed by me personally
- [x] Changes have been tested locally, the loading state, data state, error state and empty state all work correctly without any errors on all the devices